### PR TITLE
fix: corrigir erro 404 ao recarregar rotas internas

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
### Resumo da Correção
Este PR adiciona o arquivo `vercel.json` com uma regra de reescrita, garantindo que o `index.html` seja servido em todas as rotas, corrigindo o erro 404 ao pressionar F5 em páginas internas.

### Issue relacionada
Rresolve: #5

### Evidências de Validação
- Acessar `/dashboard` na aplicação publicada.
- Pressionar F5.
- A página recarrega normalmente (sem erro 404).