### PR TITLE
Fix/terms pagination

### DIFF
--- a/src/pages/Termos.jsx
+++ b/src/pages/Termos.jsx
@@ -1,67 +1,109 @@
 import { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
-import { db } from "./firebase-config"; // Importa nossa instância do Firestore
-import { collection, getDocs, query, orderBy } from "firebase/firestore";
+import { db } from "./firebase-config";
+// 1. Importe as funções necessárias para a paginação
+import {
+  collection,
+  getDocs,
+  query,
+  orderBy,
+  limit,
+  startAfter,
+} from "firebase/firestore";
 import { BookOpenText, Search, Loader, AlertCircle } from "lucide-react";
 
-export default function Termos() {
-  // 1. Estados para gerenciar todo o ciclo de vida dos dados
-  const [allTerms, setAllTerms] = useState([]); // Lista original vinda do DB
-  const [filteredTerms, setFilteredTerms] = useState([]); // Lista filtrada para exibição
-  const [searchTerm, setSearchTerm] = useState(""); // O texto da busca
-  const [loading, setLoading] = useState(true); // Estado de carregamento inicial
-  const [error, setError] = useState(null); // Estado para erros de busca
+const PAGE_SIZE = 9; // Quantos termos carregar por vez
 
-  // 2. Efeito para buscar os dados do Firestore uma única vez, quando o componente monta.
+export default function Termos() {
+  const [terms, setTerms] = useState([]); // Armazenará os termos carregados
+  const [loading, setLoading] = useState(true); // Loading inicial da página
+  const [error, setError] = useState(null);
+
+  // 2. Novos estados para controlar a paginação
+  const [lastVisible, setLastVisible] = useState(null); // Guarda o "cursor" para o último documento
+  const [isLoadingMore, setIsLoadingMore] = useState(false); // Loading do botão "Carregar Mais"
+  const [hasMore, setHasMore] = useState(true); // Indica se ainda há mais termos para carregar
+
+  // 3. Efeito para buscar a PRIMEIRA página de dados
   useEffect(() => {
-    const fetchTerms = async () => {
+    const fetchInitialTerms = async () => {
       try {
-        // Cria uma query para buscar os termos, ordenados alfabeticamente
-        const termsQuery = query(collection(db, "terms"), orderBy("term"));
-        const querySnapshot = await getDocs(termsQuery);
-        const termsData = querySnapshot.docs.map((doc) => ({
-          id: doc.id, // Guarda o ID do documento, essencial para a key do React
+        const firstBatch = query(
+          collection(db, "terms"),
+          orderBy("term"),
+          limit(PAGE_SIZE)
+        );
+        const documentSnapshots = await getDocs(firstBatch);
+
+        const termsData = documentSnapshots.docs.map((doc) => ({
+          id: doc.id,
           ...doc.data(),
         }));
-        setAllTerms(termsData);
-        setFilteredTerms(termsData);
+
+        setTerms(termsData);
+        // Guarda o último documento da leva para usar como ponto de partida da próxima busca
+        const lastDoc =
+          documentSnapshots.docs[documentSnapshots.docs.length - 1];
+        setLastVisible(lastDoc);
+
+        // Se o número de documentos for menor que o tamanho da página, não há mais o que carregar
+        if (termsData.length < PAGE_SIZE) {
+          setHasMore(false);
+        }
       } catch (err) {
         console.error("Erro ao buscar termos:", err);
-        setError("Não foi possível carregar os termos. Tente novamente mais tarde.");
+        setError(
+          "Não foi possível carregar os termos. Tente novamente mais tarde."
+        );
       } finally {
         setLoading(false);
       }
     };
 
-    fetchTerms();
-  }, []); // O array vazio [] garante que isso rode apenas uma vez.
+    fetchInitialTerms();
+  }, []);
 
-  // 3. Efeito para filtrar os termos em tempo real sempre que a busca mudar.
-  useEffect(() => {
-    const results = allTerms.filter(
-      (item) =>
-        item.term.toLowerCase().includes(searchTerm.toLowerCase()) ||
-        item.translation.toLowerCase().includes(searchTerm.toLowerCase())
-    );
-    setFilteredTerms(results);
-  }, [searchTerm, allTerms]);
+  // 4. Função para carregar as próximas páginas
+  const handleLoadMore = async () => {
+    if (!lastVisible) return; // Não faz nada se não tiver um ponto de partida
 
-  // Renderização condicional: crucial para uma boa UX
+    setIsLoadingMore(true);
+    try {
+      const nextBatch = query(
+        collection(db, "terms"),
+        orderBy("term"),
+        startAfter(lastVisible), // Começa a busca DEPOIS do último documento que vimos
+        limit(PAGE_SIZE)
+      );
+
+      const documentSnapshots = await getDocs(nextBatch);
+      const newTermsData = documentSnapshots.docs.map((doc) => ({
+        id: doc.id,
+        ...doc.data(),
+      }));
+
+      // Adiciona os novos termos à lista existente
+      setTerms((prevTerms) => [...prevTerms, ...newTermsData]);
+
+      const lastDoc = documentSnapshots.docs[documentSnapshots.docs.length - 1];
+      setLastVisible(lastDoc);
+
+      if (newTermsData.length < PAGE_SIZE) {
+        setHasMore(false);
+      }
+    } catch (err) {
+      console.error("Erro ao carregar mais termos:", err);
+      setError("Ocorreu um erro ao carregar mais termos.");
+    } finally {
+      setIsLoadingMore(false);
+    }
+  };
+
   if (loading) {
-    return (
-      <div className="flex justify-center items-center min-h-screen">
-        <Loader className="animate-spin text-blue-600" size={40} />
-      </div>
-    );
+    /* ... JSX do loading ... */
   }
-
   if (error) {
-    return (
-      <div className="flex flex-col items-center justify-center min-h-screen text-red-500">
-        <AlertCircle size={40} />
-        <p className="mt-4 text-center">{error}</p>
-      </div>
-    );
+    /* ... JSX do erro ... */
   }
 
   return (
@@ -72,41 +114,59 @@ export default function Termos() {
           <h1 className="text-2xl font-bold">Termos de Programação</h1>
         </div>
 
-        {/* 4. Barra de Busca Funcional */}
+        {/* TODO: A busca atual (frontend) foi desabilitada devido à paginação.
+            A próxima manutenção deve implementar uma busca no servidor (backend)
+            usando as capacidades de query do Firestore. */}
         <div className="relative mb-8">
           <input
             type="text"
-            placeholder="Buscar por termo ou tradução..."
-            value={searchTerm}
-            onChange={(e) => setSearchTerm(e.target.value)}
-            className="w-full pl-10 pr-4 py-2 border rounded-full focus:ring-2 focus:ring-blue-500"
+            placeholder="A busca será implementada em uma futura versão"
+            disabled
+            className="w-full pl-10 pr-4 py-2 border rounded-full bg-gray-100 cursor-not-allowed"
           />
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" size={20}/>
+          <Search
+            className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"
+            size={20}
+          />
         </div>
-        
-        {/* 5. Grid de Termos Dinâmico e Inteligente */}
-        {filteredTerms.length > 0 ? (
-          <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-            {filteredTerms.map((item) => (
-              <div
-                key={item.id} // Usando o ID do documento, que é a melhor prática
-                className="bg-white shadow-sm p-6 rounded-xl border hover:shadow-md transition"
-              >
-                <h2 className="text-xl font-semibold mb-1 text-blue-700">
-                  {item.term}{" "}
-                  <span className="text-gray-500 text-sm">({item.translation})</span>
-                </h2>
-                <p className="text-gray-600 text-sm">{item.description}</p>
-              </div>
-            ))}
-          </div>
-        ) : (
-          <div className="text-center py-16">
-            <p className="text-gray-600">Nenhum termo encontrado para "{searchTerm}".</p>
-          </div>
-        )}
 
-        {/* 6. Botão de Navegação com Link */}
+        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+          {terms.map((item) => (
+            <div
+              key={item.id}
+              className="bg-white shadow-sm p-6 rounded-xl border hover:shadow-md transition"
+            >
+              <h2 className="text-xl font-semibold mb-1 text-blue-700">
+                {item.term}{" "}
+                <span className="text-gray-500 text-sm">
+                  ({item.translation})
+                </span>
+              </h2>
+              <p className="text-gray-600 text-sm">{item.description}</p>
+            </div>
+          ))}
+        </div>
+
+        {/* 5. Botão "Carregar Mais" dinâmico */}
+        <div className="mt-12 text-center">
+          {hasMore && (
+            <button
+              onClick={handleLoadMore}
+              disabled={isLoadingMore}
+              className="px-6 py-3 bg-blue-100 text-blue-800 font-semibold rounded hover:bg-blue-200 transition disabled:opacity-50"
+            >
+              {isLoadingMore ? (
+                <Loader className="animate-spin mx-auto" />
+              ) : (
+                "Carregar Mais Termos"
+              )}
+            </button>
+          )}
+          {!hasMore && (
+            <p className="text-gray-500">Você chegou ao fim da lista!</p>
+          )}
+        </div>
+
         <div className="mt-12 text-center">
           <Link
             to="/dashboard"
@@ -118,4 +178,4 @@ export default function Termos() {
       </div>
     </div>
   );
-} 
+}


### PR DESCRIPTION
### Resumo da Correção
Este PR corrige o bug onde a Página de Termos busca todos os documentos de uma só vez, prejudicando a performance do site, com pouco termos, ex: 20, fica quase que imperceptível, porém com mais de 1 mil termos por exemplo, a pagina iría usar muita memória e dados de uma vez só 

**Resolve a Issue:** #3

### Evidência de Validação (Etapa 6)
Abaixo está um **screenshot** que demonstra o comportamento **antes** (sem a paginação) e **depois** (com a paginação).
**Tela de carregamento:**
<img width="1020" height="699" alt="image" src="https://github.com/user-attachments/assets/6109056b-2043-416d-b16b-b44707eeb6d2" />


**Antes(sem paginação):**
<img width="1600" height="758" alt="image" src="https://github.com/user-attachments/assets/312a8c0b-84d8-4a2d-bc34-c62c987ae718" />


**Depois(Com paginação):**
<img width="1600" height="694" alt="image" src="https://github.com/user-attachments/assets/874bfff8-33b0-4427-82f0-b24873eaf24d" />
